### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
 gem "activeadmin"
+gem "redcarpet"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
 gem "activeadmin"
 gem "redcarpet"
+gem "rouge"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    rouge (3.26.0)
     rubocop (1.18.2)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -307,6 +308,7 @@ DEPENDENCIES
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
   redcarpet
+  rouge
   rubocop-performance
   rubocop-rails
   sass-rails (>= 6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -305,6 +306,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  redcarpet
   rubocop-performance
   rubocop-rails
   sass-rails (>= 6)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,7 @@ body {
 .app-navbar {
   margin: 0 auto;
 }
+
+a:hover {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -1,0 +1,46 @@
+@import 'bootstrap/scss/bootstrap';
+
+.markdown {
+  table {
+    @extend .table;
+    display: block;
+    overflow-x: scroll;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    border: initial;
+
+    thead {
+      background-color: #eeffff;
+    }
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    text-align: left;
+  }
+
+  pre {
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
+    background-color: #f6ffff;
+    padding: 0.5rem;
+    margin: 1rem 0;
+    border: 2px dashed #d6dddd;
+
+    code {
+      table.rouge-table {
+        margin: 0;
+
+        td.rouge-code {
+          padding: 0;
+          vertical-align: top;
+
+          pre {
+            padding: 5px 10px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/rouge.scss.erb
+++ b/app/assets/stylesheets/rouge.scss.erb
@@ -1,0 +1,1 @@
+<%= Rouge::Themes::Github.render(scope: '.highlight') %>

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,5 +3,7 @@ class TextsController < ApplicationController
     @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
   end
 
-  def show; end
+  def show
+    @text = Text.find(params[:id])
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,30 @@
+module MarkdownHelper
+  def markdown(text)
+    renderer = Redcarpet::Render::HTML.new(render_options)
+    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
+  end
+
+  private
+
+  def render_options
+    {
+      filter_html: false, # htmlを無効化
+      hard_wrap: true, # 改行を br 要素に変換
+      link_attributes: { target: "_blank", rel: "noopener" }, # リンクの設定
+    }
+  end
+
+  def extensions
+    {
+      autolink: true, # http https ftpで始まる文字列を自動リンク
+      fenced_code_blocks: true, # コードブロックを解析
+      no_intra_emphasis: true, # 単語内の強調を解析しない
+      tables: true, # 	テーブルを解析
+      space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
+      hard_wrap: true, # 改行を br 要素に変換
+      xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
+      lax_html_blocks: true, # 複数行のコードの前後に空行が不要
+    # strikethrough: true, # 取り消し線(~)を解析する
+    }
+  end
+end

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,12 +1,14 @@
 <div class="col-12 col-md-6 col-lg-4 text-card-container">
-  <div class="card card-style">
-    <div class="card-header p-0">
-      <img class="card-img-top img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="no-image">
+  <%= link_to text_path(text) do %>
+    <div class="card card-style">
+      <div class="card-header p-0">
+        <img class="card-img-top img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="no-image">
+      </div>
+      <div class="card-body text-card-body">
+        <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
+        <p class="card-text" style="margin-top: 20px;"><%= text.title %></p>
+        <p>【<%= text.genre_i18n %>】</p>
+      </div>
     </div>
-    <div class="card-body text-card-body">
-      <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
-      <p class="card-text" style="margin-top: 20px;"><%= text.title %></p>
-      <p>【<%= text.genre_i18n %>】</p>
-    </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,2 +1,6 @@
-<h1 class="text-center" style="margin-bottom: 30px;"><%= @text.title %></h1>
-<%= @text.content %>
+<h1 class="text-center" style="margin-bottom: 30px;">
+  <%= @text.title %>
+</h1>
+<div class="markdown">
+  <%= markdown(@text.content) %>
+</div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,2 +1,2 @@
-<h1>Texts#show</h1>
-<p>Find me in app/views/texts/show.html.erb</p>
+<h1 class="text-center" style="margin-bottom: 30px;"><%= @text.title %></h1>
+<%= @text.content %>


### PR DESCRIPTION
## 実装内容
-  一覧ページから詳細ページへの移動を実装
-  `redcarpet`, `rouge`をインストール
   -  `app/helpers/markdown_helper.rb` を作成してマークダウンの設定を追加
   -  `app/assets/stylesheets/rouge.scss.erb` を作成し，`Rouge` のシンタックスハイライト用のスタイルを追加
   -  `app/assets/stylesheets/markdown.scss` を作成し，マークダウン専用のスタイルを追加
-  テキスト教材の詳細ページを実装

## 確認内容
-  一覧ページのカードから対応する詳細ページに遷移できること
-  詳細ページで，下図のようにマークダウンを反映したスタイルとなっていること

## 参考資料
[【公式】Redcarpet](https://github.com/vmg/redcarpet)
[【公式】Rouge](https://github.com/rouge-ruby/rouge)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
