### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "2.7.3"
 
+gem "activeadmin"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
 gem "devise-bootstrap-views"
@@ -13,12 +14,11 @@ gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 gem "rails", "~> 6.1.1"
 gem "rails-i18n", "~> 6.0"
+gem "redcarpet"
+gem "rouge"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem "activeadmin"
-gem "redcarpet"
-gem "rouge"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -28,5 +28,5 @@ ActiveAdmin.register_page "Dashboard" do
     #     end
     #   end
     # end
-  end # content
+  end
 end

--- a/app/admin/movies.rb
+++ b/app/admin/movies.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register Movie do
-
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #

--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register Text do
-
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register User do
-
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,10 +1,10 @@
 class MoviesController < ApplicationController
   def index
-    if params[:genre] == "php"
-      @movies = Movie.where(genre: Movie::PHP_GENRE_LIST)
-    else
-      @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
-    end
+    @movies = if params[:genre] == "php"
+                Movie.where(genre: Movie::PHP_GENRE_LIST)
+              else
+                Movie.where(genre: Movie::RAILS_GENRE_LIST)
+              end
   end
 
   def show; end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,10 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    if params[:genre] == "php"
+      @movies = Movie.where(genre: Movie::PHP_GENRE_LIST)
+    else
+      @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    end
   end
 
   def show; end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def page_title
+    if params[:genre] == "php"
+      "PHP 動画"
+    else
+      "Ruby/Rails 動画"
+    end
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -10,7 +10,7 @@ module MarkdownHelper
     {
       filter_html: false, # htmlを無効化
       hard_wrap: true, # 改行を br 要素に変換
-      link_attributes: { target: "_blank", rel: "noopener" }, # リンクの設定
+      link_attributes: { target: "_blank", rel: "noopener" } # リンクの設定
     }
   end
 
@@ -23,8 +23,8 @@ module MarkdownHelper
       space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
       hard_wrap: true, # 改行を br 要素に変換
       xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
-      lax_html_blocks: true, # 複数行のコードの前後に空行が不要
-    # strikethrough: true, # 取り消し線(~)を解析する
+      lax_html_blocks: true # 複数行のコードの前後に空行が不要
+      # strikethrough: true, # 取り消し線(~)を解析する
     }
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,6 +1,6 @@
 class AdminUser < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, 
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -11,7 +11,7 @@ class Movie < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5,
+    php: 5
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -11,8 +11,9 @@ class Movie < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5
+    php: 5,
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php].freeze
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,6 @@
-<h1 class="text-center" style="margin-bottom: 2rem;">Ruby/Rails 動画</h1>
+<h1 class="text-center" style="margin-bottom: 2rem;">
+  <%= page_title %>
+</h1>
 <div class="container">
   <div class="row row-cols-3">
     <%= render partial: "movie", collection: @movies %>

--- a/db/migrate/20210806095159_devise_create_admin_users.rb
+++ b/db/migrate/20210806095159_devise_create_admin_users.rb
@@ -32,7 +32,6 @@ class DeviseCreateAdminUsers < ActiveRecord::Migration[6.1]
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
 
-
       t.timestamps null: false
     end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ CSV.foreach("db/csv_data/text_data.csv", headers: true) do |row|
   Text.create(
     genre: row["genre"],
     title: row["title"],
-    content: row["content"],
+    content: row["content"]
   )
 end
 puts "テキスト教材データの投入に成功しました。"
@@ -24,7 +24,7 @@ CSV.foreach("db/csv_data/movie_data.csv", headers: true) do |row|
   Movie.create(
     genre: row["genre"],
     title: row["title"],
-    url: row["url"],
+    url: row["url"]
   )
 end
 puts "動画教材データの投入に成功しました。"


### PR DESCRIPTION
## 実装内容

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正

- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」とする

## 確認内容

- 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- クエリパラメータ ```?genre=php``` を ```php``` 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行