### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,10 +1,10 @@
 class TextsController < ApplicationController
   def index
-    if params[:genre] == "php"
-      @texts = Text.where(genre: Text::PHP_GENRE_LIST)
-    else
-      @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
-    end
+    @texts = if params[:genre] == "php"
+               Text.where(genre: Text::PHP_GENRE_LIST)
+             else
+               Text.where(genre: Text::RAILS_GENRE_LIST)
+             end
   end
 
   def show

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,10 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    if params[:genre] == "php"
+      @texts = Text.where(genre: Text::PHP_GENRE_LIST)
+    else
+      @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    end
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,12 @@ module ApplicationHelper
       "Ruby/Rails 動画"
     end
   end
+
+  def text_page_title
+    if params[:genre] == "php"
+      "PHP テキスト教材"
+    else
+      "Ruby/Rails テキスト教材"
+    end
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -11,8 +11,9 @@ class Text < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5
+    php: 5,
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php].freeze
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -11,7 +11,7 @@ class Text < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5,
+    php: 5
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,4 +1,6 @@
-<h1 class="text-center">Ruby/Rails テキスト教材</h1>
+<h1 class="text-center">
+  <%= text_page_title %>
+</h1>
 <div class="container">
   <div class="row row-cols-3">
     <%= render @texts %>


### PR DESCRIPTION
## 実装内容

- PHP動画教材ページで「PHPのテキスト教材のみ」が表示されるように修正

- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする

## 確認内容

- 「Ruby/Railsテキスト教材」に「PHPテキスト」が含まれていないことを確認
- 「PHPテキスト教材」に「PHPテキスト教材」のみが表示されていることを確認
- クエリパラメータ ```?genre=php``` を ```php``` 以外に変更してアクセスした際は「Ruby/Railsテキスト教材」が表示されることを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行