### PR TITLE
テキスト教材の読破済み機能

### DIFF
--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,11 @@
 class ReadProgressesController < ApplicationController
   def create
-    current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_to request.referer
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.create!(text_id: @text.id)
   end
 
   def destroy
-    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_to request.referer
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.find_by(text_id: @text.id).destroy!
   end
 end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,11 @@
+class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_to request.referer
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_to request.referer
+  end
+end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,10 +1,10 @@
 class TextsController < ApplicationController
   def index
     @texts = if params[:genre] == "php"
-        Text.includes(:read_progresses).where(genre: Text::PHP_GENRE_LIST)
-      else
-        Text.includes(:read_progresses).where(genre: Text::RAILS_GENRE_LIST)
-      end
+               Text.includes(:read_progresses).where(genre: Text::PHP_GENRE_LIST)
+             else
+               Text.includes(:read_progresses).where(genre: Text::RAILS_GENRE_LIST)
+             end
   end
 
   def show

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,10 +1,10 @@
 class TextsController < ApplicationController
   def index
     @texts = if params[:genre] == "php"
-               Text.where(genre: Text::PHP_GENRE_LIST)
-             else
-               Text.where(genre: Text::RAILS_GENRE_LIST)
-             end
+        Text.includes(:read_progresses).where(genre: Text::PHP_GENRE_LIST)
+      else
+        Text.includes(:read_progresses).where(genre: Text::RAILS_GENRE_LIST)
+      end
   end
 
   def show

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,4 @@
+class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,4 +1,8 @@
 class ReadProgress < ApplicationRecord
   belongs_to :user
   belongs_to :text
+
+  validates :user_id, uniqueness: {
+              scope: :text_id,
+            }
 end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -3,6 +3,6 @@ class ReadProgress < ApplicationRecord
   belongs_to :text
 
   validates :user_id, uniqueness: {
-              scope: :text_id,
-            }
+    scope: :text_id
+  }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -18,4 +18,8 @@ class Text < ApplicationRecord
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
   PHP_GENRE_LIST = %w[php].freeze
+
+  def read_progress_by?(user)
+    read_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -13,7 +13,7 @@ class Text < ApplicationRecord
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5,
+    php: 5
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -5,13 +5,15 @@ class Text < ApplicationRecord
     validates :content
   end
 
+  has_many :read_progresses, dependent: :destroy
+
   enum genre: {
     invisible: 0,
     basic: 1,
     git: 2,
     ruby: 3,
     rails: 4,
-    php: 5
+    php: 5,
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -20,6 +20,6 @@ class Text < ApplicationRecord
   PHP_GENRE_LIST = %w[php].freeze
 
   def read_progress_by?(user)
-    read_progresses.exists?(user_id: user.id)
+    read_progresses.any? { |read_progress| read_progress.user_id == user.id }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 
+  has_many :read_progresses, dependent: :destroy
+
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("text-<%= @text.id %>").innerHTML = "<%= j render("texts/read_progress", text: @text) %>"

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("text-<%= @text.id %>").innerHTML = "<%= j render("texts/disread_progress", text: @text) %>"

--- a/app/views/texts/_disread_progress.html.erb
+++ b/app/views/texts/_disread_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-secondary btn-block", remote: true %>

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-primary btn-block", remote: true %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -5,11 +5,13 @@
         <img class="card-img-top img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="no-image">
       </div>
       <div class="card-body text-card-body">
-        <% if text.read_progress_by?(current_user) %>
-          <%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-primary btn-block" %>
-        <% else %>
-          <%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-secondary btn-block" %>
-        <% end %>
+        <p id="text-<%= text.id %>">
+          <% if text.read_progress_by?(current_user) %>
+            <%= render "read_progress", text: text %>
+          <% else %>
+            <%= render "disread_progress", text: text %>
+          <% end %>
+        </p>
         <p class="card-text" style="margin-top: 20px;"><%= text.title %></p>
         <p>【<%= text.genre_i18n %>】</p>
       </div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -5,7 +5,11 @@
         <img class="card-img-top img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="no-image">
       </div>
       <div class="card-body text-card-body">
-        <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
+        <% if text.read_progress_by?(current_user) %>
+          <%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, class: "btn btn-primary btn-block" %>
+        <% else %>
+          <%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, class: "btn btn-secondary btn-block" %>
+        <% end %>
         <p class="card-text" style="margin-top: 20px;"><%= text.title %></p>
         <p>【<%= text.genre_i18n %>】</p>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,7 +3,10 @@ ja:
     models:
       text: テキスト教材
       movie: 動画教材
+      read_progress: 読破済み
   attributes:
+    user: ユーザー
+    text: テキスト教材
     genre: ジャンル
     title: タイトル
     content: テキスト

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   root "texts#index"
   devise_for :users
-  resources :texts, only: [:index, :show]
+  resources :texts, only: [:index, :show] do
+    resource :read_progresses, only: [:create, :destroy]
+  end
   resources :movies, only: [:index, :show]
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"

--- a/db/migrate/20210809135627_create_read_progresses.rb
+++ b/db/migrate/20210809135627_create_read_progresses.rb
@@ -1,0 +1,10 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210809135627_create_read_progresses.rb
+++ b/db/migrate/20210809135627_create_read_progresses.rb
@@ -6,5 +6,6 @@ class CreateReadProgresses < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+    add_index :read_progresses, [:user_id, :text_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_06_095201) do
+ActiveRecord::Schema.define(version: 2021_08_09_135627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_08_06_095201) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -66,4 +76,6 @@ ActiveRecord::Schema.define(version: 2021_08_06_095201) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
## 実装内容

- 読破済み機能に使用する ReadProgress モデルを作成

- テキスト教材一覧ページに読破済み機能を実装

## 確認内容

- 以下を確認
```
rails c -s

# Railsコンソール起動後
user = User.first
text, text2 = Text.limit(2)
ReadProgress.delete_all

user.read_progresses.create!(text_id: text.id)
user.read_progresses.create!(text_id: text2.id)

ReadProgress.count
#=> 2

text.read_progresses.create!(user_id: user.id)
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: Userは同じテキスト教材を2回以上読破済みにはできません

ReadProgress.create!
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: ユーザーを入力してください, テキスト教材を入力してください
```
## 参考資料（必要があれば）

- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
- [x] テキスト教材一覧ページの読破済み機能が動作していることを確認